### PR TITLE
Add location specific class to topnav containers

### DIFF
--- a/_topnav.php
+++ b/_topnav.php
@@ -1,11 +1,11 @@
 <nav class="topnav">
   <div class="container">
     <div class="nav-wrapper">
-      <?php wp_nav_menu ( array( 'theme_location' => 'topnav-left' ) ); ?>
+      <?php wp_nav_menu ( array( 'theme_location' => 'topnav-left', 'container_class' => 'topnav-left-container' ) ); ?>
       <div class="logo-wrapper">
         <?php the_custom_logo(); ?>
       </div>
-      <?php wp_nav_menu ( array( 'theme_location' => 'topnav-right' ) ); ?>
+      <?php wp_nav_menu ( array( 'theme_location' => 'topnav-right', 'container_class' => 'topnav-right-container' ) ); ?>
     </div>
     <div class="social-links">
       <h4><a href="#">Careers &nbsp |</a></h4>

--- a/styles/layout/_topnav.scss
+++ b/styles/layout/_topnav.scss
@@ -13,9 +13,9 @@
     @include position(absolute, null 0 0 0);
   }
 
-  .menu-main-menu-1-container,
+  .topnav-left-container,
   .logo-wrapper,
-  .menu-main-menu-2-container {
+  .topnav-right-container {
     @include span(4);
 
     > ul > li {


### PR DESCRIPTION
I didn't notice that the container class was based on the NAME of the
menu. The name entered in the wp admin which has nothing to do with the
theme at all.
