### PR TITLE
Fix social-link styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -86,7 +86,7 @@ h2{
 	font-size:30px;
 }
 
-h1>a:link, h2>a:link, h3>a:link, h4>a:link, h5>a:link, h6>a:link, h1>a:visited, h2>a:visited, h3>a:visited, h4>a:visited, h5>a:visited, h6>a:visited{
+h1>a, h2>a, h3>a, h4>a, h5>a, h6>a, h1>a, h2>a, h3>a, h4>a, h5>a, h6>a{
     color:#fff;
     text-decoration:none;
 }
@@ -97,7 +97,7 @@ h1>a:focus,h2>a:focus,h3>a:focus,h4>a:focus,h5>a:focus,h6>a:focus{
     color:#e3be73;
 }
 
-a:link, a:visited{
+a {
     text-decoration:none;
     color:#B5A36A;
     transition:all 0.3s;

--- a/styles/components/_social_links.scss
+++ b/styles/components/_social_links.scss
@@ -8,12 +8,13 @@
     margin: 0 0.5em;
   }
 
-  a:link {
-    color: $link-color;
+  a {
+    color: $brand-primary;
 
     &:hover {
-      color: $link-color-active;
+      color: $brand-primary-low;
       border-bottom-color: transparent;
+      text-decoration: none;
     }
   }
 

--- a/styles/layout/_footer.scss
+++ b/styles/layout/_footer.scss
@@ -76,10 +76,22 @@
     float: left;
   }
 
-  .social-links h4 {
-    border-bottom: none;
-    text-transform: none;
-    letter-spacing: 0;
+  .social-links {
+    a {
+      color: $brand-primary;
+    }
+
+    a:hover {
+      color: $brand-primary-low;
+      text-decoration: none;
+      border-bottom-color: transparent;
+    }
+
+    h4 {
+      border-bottom: none;
+      text-transform: none;
+      letter-spacing: 0;
+    }
   }
 
   @media (max-width: 450px) {

--- a/styles/layout/_topnav.scss
+++ b/styles/layout/_topnav.scss
@@ -119,6 +119,7 @@ $topnav-offset: $topnav-height - $topnav-menu-outerheight;
 
       &:hover {
         color: $submenu-link-color-active;
+        text-decoration: none;
       }
     }
   }


### PR DESCRIPTION
The old styles used both :link and :visited selectors. :visited refers to links which the user has visited, while :link refers only to links which the user has not visited.

We have no intentions of styling visited links differently, and our new styles were being incorrectly applied to only :link so here we homogeonize both the old and new anchor styles.
