### PR TITLE
Fix IE logo blur

### DIFF
--- a/partials/_topnav.php
+++ b/partials/_topnav.php
@@ -4,7 +4,7 @@
     <div class="nav-wrapper">
       <?php wp_nav_menu ( array( 'theme_location' => 'topnav-left', 'container_class' => 'topnav-left-container' ) ); ?>
       <div class="logo-wrapper">
-        <a href="<?php echo home_url(); ?>" title="Windley Contracting - Home" class="nav-logo logo"><img src="<?php echo get_template_directory_uri(); ?>/images/logo.png" alt="Windley Contracting logo"></a>
+        <a href="<?php echo home_url(); ?>" title="Windley Contracting - Home" class="nav-logo logo"></a>
       </div>
       <?php wp_nav_menu ( array( 'theme_location' => 'topnav-right', 'container_class' => 'topnav-right-container' ) ); ?>
     </div>

--- a/styles/layout/_topnav.scss
+++ b/styles/layout/_topnav.scss
@@ -168,5 +168,6 @@ body.past-scroll-top .topnav {
   to {
     height: 2 * $topnav-menu-outerheight;
     width: 2 * $topnav-menu-outerheight * $topnav-logo-width / $topnav-logo-height;
+    background-image: url(../../images/logo-small.png);
   }
 }

--- a/styles/layout/_topnav.scss
+++ b/styles/layout/_topnav.scss
@@ -74,7 +74,7 @@ $topnav-logo-width: 303px;
     @include position(absolute, $topnav-height null null 50%);
     height: $topnav-logo-height;
     width: $topnav-logo-width;
-    background: url(../../images/logo.png) 100% / cover;
+    background: url(../../images/logo.png), url(../../images/logo-small.png) 100% / cover;
   }
 
   .menu {

--- a/styles/layout/_topnav.scss
+++ b/styles/layout/_topnav.scss
@@ -5,6 +5,10 @@ $topnav-menu-padding: 16px;
 $topnav-menu-outerheight: $topnav-menu-height + 2 * $topnav-menu-padding;
 $topnav-offset: $topnav-height - $topnav-menu-outerheight;
 
+$topnav-logo-height: 140px;
+$topnav-logo-width: 303px;
+
+
 .topnav-spacer {
   height: $topnav-height;
 
@@ -68,12 +72,9 @@ $topnav-offset: $topnav-height - $topnav-menu-outerheight;
   .nav-logo {
     @include transform(translate(-50%, -50%));
     @include position(absolute, $topnav-height null null 50%);
-
-    img {
-      max-width: none;
-      height: 140px;
-      transition: height 250ms;
-    }
+    height: $topnav-logo-height;
+    width: $topnav-logo-width;
+    background: url(../../images/logo.png) 100% / cover;
   }
 
   .menu {
@@ -149,12 +150,23 @@ body.past-scroll-top .topnav {
   top: -$topnav-offset;
   transition: top 250ms;
 
-  .nav-logo img {
-    height: 2 * $topnav-menu-outerheight;
+  .nav-logo {
+    @include animation(smallLogo 250ms forwards);
   }
 
   .social-links {
     opacity: 0; // in case we don't quite get them off page
     transition: opacity 250ms 250ms;
+  }
+}
+
+@include keyframes(smallLogo) {
+  from {
+    height: 140px;
+  }
+
+  to {
+    height: 2 * $topnav-menu-outerheight;
+    width: 2 * $topnav-menu-outerheight * $topnav-logo-width / $topnav-logo-height;
   }
 }


### PR DESCRIPTION
IE can't resize images, so we need to swap out the big logo for a small one when our animation is done. We can't transition BETWEEN images, so we'll animate sizes, then substitute.
